### PR TITLE
Fix default policy with skopeo 1.17.0 onwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can download the static binary from the [GitHub Releases](https://github.com
 
 ```bash
 # pick any version you want from the releases page
-version="1.14.0"
+version="1.20.0"
 
 # download the static binary
 sudo curl -L --output /usr/local/bin/skopeo https://github.com/felipecrs/skopeo-bin/releases/download/v${version}/skopeo.linux-amd64
@@ -45,7 +45,7 @@ If you want to bundle skopeo in a docker image, you have an [easier way](https:/
 ```Dockerfile
 FROM ubuntu:20.04
 
-COPY --from=ghcr.io/felipecrs/skopeo-bin:1.14.0 / /usr/local/bin/
+COPY --from=ghcr.io/felipecrs/skopeo-bin:1.20.0 / /usr/local/bin/
 ```
 
 ## Building skopeo-bin
@@ -65,7 +65,7 @@ docker build https://github.com/felipecrs/skopeo-bin.git --output .
 As the release process is not automated yet, you can run the following command to release a new version:
 
 ```console
-scripts/build_and_release.sh 1.14.0
+scripts/build_and_release.sh 1.20.0
 ```
 
 If no version is provided, the latest version of skopeo will be assumed.

--- a/patches/embed-policy.patch
+++ b/patches/embed-policy.patch
@@ -1,0 +1,53 @@
+diff --git a/Makefile b/Makefile
+index 4d106589..5a5411d7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -160,7 +160,7 @@ clean:
+ install: install-binary install-docs install-completions
+ 	install -d -m 755 ${DESTDIR}${LOOKASIDEDIR}
+ 	install -d -m 755 ${DESTDIR}${CONTAINERSCONFDIR}
+-	install -m 644 default-policy.json ${DESTDIR}${CONTAINERSCONFDIR}/policy.json
++	install -m 644 cmd/skopeo/fixtures/default-policy.json ${DESTDIR}${CONTAINERSCONFDIR}/policy.json
+ 	install -d -m 755 ${DESTDIR}${REGISTRIESDDIR}
+ 	install -m 644 default.yaml ${DESTDIR}${REGISTRIESDDIR}/default.yaml
+ 
+diff --git a/default-policy.json b/cmd/skopeo/fixtures/default-policy.json
+similarity index 100%
+rename from default-policy.json
+rename to cmd/skopeo/fixtures/default-policy.json
+diff --git a/cmd/skopeo/main.go b/cmd/skopeo/main.go
+index 8b8de3c7..1052f6b3 100644
+--- a/cmd/skopeo/main.go
++++ b/cmd/skopeo/main.go
+@@ -2,7 +2,9 @@ package main
+ 
+ import (
+ 	"context"
++	_ "embed"
+ 	"fmt"
++	"os"
+ 	"strings"
+ 	"time"
+ 
+@@ -137,6 +139,9 @@ func main() {
+ 	}
+ }
+ 
++//go:embed fixtures/default-policy.json
++var defaultPolicyBytes []byte
++
+ // getPolicyContext returns a *signature.PolicyContext based on opts.
+ func (opts *globalOptions) getPolicyContext() (*signature.PolicyContext, error) {
+ 	var policy *signature.Policy // This could be cached across calls in opts.
+@@ -145,6 +150,11 @@ func (opts *globalOptions) getPolicyContext() (*signature.PolicyContext, error)
+ 		policy = &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+ 	} else if opts.policyPath == "" {
+ 		policy, err = signature.DefaultPolicy(nil)
++		// Check if the error is due to the default policy file not being found
++		// so we don't supress other errors like bad JSON in the policy file.
++		if err != nil && (strings.Contains(err.Error(), "no policy.json file found") || os.IsNotExist(err)) {
++			policy, err = signature.NewPolicyFromBytes(defaultPolicyBytes)
++		}
+ 	} else {
+ 		policy, err = signature.NewPolicyFromFile(opts.policyPath)
+ 	}


### PR DESCRIPTION
The [previous patch](https://github.com/containers/skopeo/pull/2014) stopped working in that version, but this new patch works for all versions.